### PR TITLE
use redirect instead of 401 for access denied

### DIFF
--- a/public/views/pages/admin/index.liquid
+++ b/public/views/pages/admin/index.liquid
@@ -15,7 +15,7 @@ layout: modules/admin/application
   assign admin_menu_items = '[]' | parse_json
   assign current_page = nil
 
-  include 'modules/permission/lib/helpers/can_do_or_unauthorized', requester: current_user, do: 'admin_pages.view'
+  include 'modules/permission/lib/helpers/can_do_or_redirect', requester: current_user, do: 'admin_pages.view'
 
   assign query_path = '/' | append: context.params.slug | append: '/' | append: context.params.path
 


### PR DESCRIPTION
# Description

If the user doesn't have access to the main admin layout then redirect instead of showing a 401

## Issue ticket number and link
https://trello.com/c/BD6S2p1Y

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
